### PR TITLE
Fix render calendar on input day month and year.

### DIFF
--- a/foundation_calendar.js
+++ b/foundation_calendar.js
@@ -257,9 +257,9 @@ $.fcdp = {
 			});
 		};
 
+		this.setFieldDate(opts, this.getFieldDate(opts));
 		this.buildCalendar(opts);
 		this.buildTime(opts);
-		this.setFieldDate(opts, this.getFieldDate(opts));
 		this.updateTimePicker(opts);
 	},
 	


### PR DESCRIPTION
Hello, 
If you set a value on your input, for example 2013-06-08 , the calendar highlights this day BUT it show the current month again, also if you click the "previous month" button it show the month before the month on our input...
Probably this is a bug , because i can see it on your demo also.

I create a pull request with the change.

Thanks for your awesome calendar . Great work.
