### PR TITLE
fixes a bug where null fields displayed with the current date/time

### DIFF
--- a/foundation_calendar.js
+++ b/foundation_calendar.js
@@ -261,6 +261,11 @@ $.fcdp = {
 		this.buildCalendar(opts);
 		this.buildTime(opts);
 		this.updateTimePicker(opts);
+
+		// workaround to make sure cleared-out field starts out cleared-out
+		if( null == this.getFieldDate(opts) ) {
+			$.fcdp.setWorkingDate(opts, null);
+		}
 	},
 	
 	buildTime: function(opts) {


### PR DESCRIPTION
Hi, hope this is a helpful fix.

I noticed that, if an input starts out with a blank value and I use the data-nullable parameter, the field displays with the current date filled in. However, if I save the form, a blank is still saved. So it's a bit misleading: the user thinks the current date will be saved, but nothing is submitted. Also, I'd prefer the behavior of having it actually start out with a blank initial value.

To fix this, I just added a setWorkingDate call after the calendar/time controls are built. Since it's setting it to null, it clears out the fields at that time.

Let me know if you have questions or I can do this better. Thanks for building such a great control!